### PR TITLE
Add gitattributes.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+kubeyard/templates/* linguist-generated=true


### PR DESCRIPTION
We can improve github languages bar if we exclude `./kubeyard/templates` from lanugage analysis.