### PR TITLE
Use rsync when uploading files to GCS

### DIFF
--- a/kubeyard/commands/deploy.py
+++ b/kubeyard/commands/deploy.py
@@ -289,7 +289,8 @@ class GCSFilesStorage(FilesStorage):
                 'gsutil',
                 '-m',
                 '-o', 'Credentials:gs_service_key_file=/service-account.json',
-                'cp', '-r', '/upload/*', 'gs://{}/{}/'.format(self.bucket_name, self.statics_directory),
+                'rsync', '-c', '-r',
+                '/upload/', 'gs://{}/{}'.format(self.bucket_name, self.statics_directory),
             )
 
 


### PR DESCRIPTION
If files don't change, it's better to use "rsync" than "cp".
Thanks to that, only changed files will be uploaded.
I chose to use option "-c" to compare files based on size and
checksums, instead of mtime, which works more reliably.

Docs: https://cloud.google.com/storage/docs/gsutil/commands/rsync