### PR TITLE
Display output when updating requirements.

### DIFF
--- a/kubeyard/commands/update_requirements.py
+++ b/kubeyard/commands/update_requirements.py
@@ -30,6 +30,7 @@ class UpdateRequirementsCommand(BaseDevelCommand):
             *self.volumes,
             self.image,
             'bash', '-c', 'freeze_requirements',
+            _out=sys.stdout.buffer,
             _err=sys.stdout.buffer,
         )
         logger.info('Requirements updated!')


### PR DESCRIPTION
Right now the only output is:

```
$ kubeyard update-requirements
11:30:11 [INFO] Checking if cluster is running and configured...
11:30:11 [INFO] Cluster is ready
11:30:11 [INFO] Updating requirements for "[image_name]:dev"...
11:30:40 [INFO] Requirements updated!
```